### PR TITLE
Disabled NULL value for translation tables

### DIFF
--- a/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
+++ b/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
@@ -198,6 +198,7 @@ class TranslatableListener implements EventSubscriber
                     'name'                 => 'translatable_id',
                     'referencedColumnName' => 'id',
                     'onDelete'             => 'CASCADE',
+                    'nullable'             => false,
                 )),
             ));
         }


### PR DESCRIPTION
The join column between the translatable and the translations should not allow NULL values? When there is a use case where this is valid, I would like to propose a parameter that can be used to change this default behavior.
