### PR TITLE
Fixing the fallbackLocale bug on the YamlDriver

### DIFF
--- a/lib/Prezent/Doctrine/Translatable/Mapping/Driver/YamlDriver.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/Driver/YamlDriver.php
@@ -66,7 +66,7 @@ class YamlDriver extends FileDriver
         if (isset($translatable['fallbackLocale'])) {
             $propertyMetadata = new PropertyMetadata($className, $translatable['fallbackLocale']);
 
-            $classMetadata->currentLocale = $propertyMetadata;
+            $classMetadata->fallbackLocale = $propertyMetadata;
             $classMetadata->addPropertyMetadata($propertyMetadata);
         }
 


### PR DESCRIPTION
On the YamlDriver, there was a typo in the fallbackLocale propertyMetadata.
