### PR TITLE
Added missing XML driver support to DoctrineAdapter

### DIFF
--- a/lib/Prezent/Doctrine/Translatable/Mapping/Driver/DoctrineAdapter.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/Driver/DoctrineAdapter.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\FileDriver as DoctrineFileDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 use Metadata\Driver\DriverChain;
 use Metadata\Driver\DriverInterface;
@@ -77,7 +78,10 @@ class DoctrineAdapter
 
         if ($omDriver instanceof DoctrineFileDriver) {
             $reflClass = new \ReflectionClass($omDriver);
-            $driverName = $omDriver instanceof SimplifiedYamlDriver ? 'YamlDriver' : $reflClass->getShortName();
+            
+            $driverName = $omDriver instanceof SimplifiedYamlDriver || $omDriver instanceof SimplifiedXmlDriver ? 
+                str_replace('Simplified', '', $reflClass->getShortName()) : $reflClass->getShortName();
+           
             $class = 'Prezent\\Doctrine\\Translatable\\Mapping\\Driver\\' . $driverName;
 
             if (class_exists($class)) {


### PR DESCRIPTION
While using the translatable in conjunction with FOSUserBundle I got this error (e.g. on `app/console cache:clear`)
````
[InvalidArgumentException]
  Cannot adapt Doctrine driver of class Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver
````

We have support for XML Drivers here, but it was not used in DoctrineAdapter. Could you please have a look at the proposed solution. Thanks.
