### PR TITLE
Added support for Doctrine 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.3",
+        "doctrine/common": "^2.3",
         "jms/metadata": "~1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.3,<2.6-dev",
+        "doctrine/common": ">=2.3",
         "jms/metadata": "~1.1"
     },
     "require-dev": {
-        "doctrine/orm": ">=2.3,<2.6-dev"
+        "doctrine/orm": ">=2.3"
     },
     "autoload": {
         "psr-0": { "Prezent\\Doctrine\\Translatable": "lib/" }


### PR DESCRIPTION
I've removed the max version to support newer versions of Doctrine. I've tested it and haven't encountered any issues.