### PR TITLE
Php 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,26 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
 
 env:
     - DOCTRINE_VERSION="2.3.*"
     - DOCTRINE_VERSION="2.4.*"
-    - DOCTRINE_VERSION="dev-master"
+    - DOCTRINE_VERSION="2.5.*"
+
+matrix:
+    include:
+        - php: 5.6
+          env: DOCTRINE_VERSION="dev-master"
+        - php: 7.0
+          env: DOCTRINE_VERSION="dev-master"
+        - php: 7.1
+          env: DOCTRINE_VERSION="dev-master"
+    exclude:
+        - php: 5.3
+          env: DOCTRINE_VERSION="2.5.*"
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "jms/metadata": "~1.1"
     },
     "require-dev": {
-        "doctrine/orm": "^2.3"
+        "doctrine/orm": "^2.3",
+        "phpunit/phpunit": "^4.8 || ^5.6"
     },
     "autoload": {
         "psr-0": { "Prezent\\Doctrine\\Translatable": "lib/" }

--- a/lib/Prezent/Doctrine/Translatable/Mapping/Driver/YamlDriver.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/Driver/YamlDriver.php
@@ -120,6 +120,6 @@ class YamlDriver extends FileDriver
      */
     protected function parse($file)
     {
-        return Yaml::parse($file);
+        return Yaml::parse(file_get_contents($file));
     }
 }


### PR DESCRIPTION
1. Fixed testing matrix to test proper doctrine versions according to PHP version
2. Added PHPUnit to requirements for development
3. Fixed Yaml parsing to pass tests on newer PHP versions