### PR TITLE
Use locale getters for setting it into annotated entity properties

### DIFF
--- a/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
+++ b/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
@@ -285,11 +285,11 @@ class TranslatableListener implements EventSubscriber
         if ($metadata instanceof TranslatableMetadata) {
 
             if ($metadata->fallbackLocale) {
-                $metadata->fallbackLocale->setValue($entity, $this->fallbackLocale);
+                $metadata->fallbackLocale->setValue($entity, $this->getFallbackLocale());
             }
 
             if ($metadata->currentLocale) {
-                $metadata->currentLocale->setValue($entity, $this->currentLocale);
+                $metadata->currentLocale->setValue($entity, $this->getCurrentLocale());
             }
         }
     }


### PR DESCRIPTION
This PR enables to extend the listener and change behavior of locale getters, ie. to use more sources of current/fallback locale and prioritize between them.