### PR TITLE
Prevent double index on translation entity

### DIFF
--- a/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
+++ b/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
@@ -258,6 +258,10 @@ class TranslatableListener implements EventSubscriber
      */
     private function hasUniqueConstraint(ClassMetadata $mapping, array $columns)
     {
+        if (!array_diff($mapping->getIdentifierColumnNames(), $columns)) {
+            return true;
+        }
+        
         if (!isset($mapping->table['uniqueConstraints'])) {
             return false;
         }


### PR DESCRIPTION
When you use a composite primary key (translatable_id, locale), you'll end up with 2 indexes:
- The primary key
- The index generated by `TranslatableListener`