### PR TITLE
Upgrade to jms/metadata v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /phpunit.xml
 /vendor
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
           env: DOCTRINE="2.6.*"
         - php: 7.3
           env: DOCTRINE="2.6.*"
-        - php: 7.4
-          env: DOCTRINE="2.6.*"
+#        - php: 7.4
+#          env: DOCTRINE="2.6.*"
 
 before_install:
   - if [ "$DOCTRINE" != "" ]; then composer require --dev --no-update doctrine/orm=$DOCTRINE; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,15 @@ sudo: false
 
 matrix:
     include:
-        - php: 5.6
-          env: COMPOSER_FLAGS="--prefer-lowest"
-        - php: 5.6
-          env: DOCTRINE="2.3.*"
-        - php: 5.6
-          env: DOCTRINE="2.4.*"
-        - php: 7.0
-          env: DOCTRINE="2.4.*"
-        - php: 7.0
-          env: DOCTRINE="2.5.*"
         - php: 7.1
           env: DOCTRINE="2.5.*"
         - php: 7.1
           env: DOCTRINE="2.6.*"
         - php: 7.2
+          env: DOCTRINE="2.6.*"
+        - php: 7.3
+          env: DOCTRINE="2.6.*"
+        - php: 7.4
           env: DOCTRINE="2.6.*"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "source": "https://github.com/prezent/doctrine-translatable"
     },
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=7.1.0",
         "doctrine/common": "^2.3",
-        "jms/metadata": "~1.1"
+        "jms/metadata": "~1.1|~2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.3",

--- a/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
+++ b/lib/Prezent/Doctrine/Translatable/EventListener/TranslatableListener.php
@@ -253,7 +253,9 @@ class TranslatableListener implements EventSubscriber
         }
 
         if ($metadata = $this->metadataFactory->getMetadataForClass($className)) {
-            if (!$metadata->reflection->isAbstract()) {
+            $reflection = new \ReflectionClass($className);
+
+            if (!$reflection->isAbstract()) {
                 $metadata->validate();
             }
         }
@@ -301,12 +303,24 @@ class TranslatableListener implements EventSubscriber
 
         if ($metadata instanceof TranslatableMetadata) {
             if ($metadata->fallbackLocale) {
-                $metadata->fallbackLocale->setValue($entity, $this->getFallbackLocale());
+                $this->setReflectionPropertyValue($entity, 'fallbackLocale', $this->getFallbackLocale());
             }
 
             if ($metadata->currentLocale) {
-                $metadata->currentLocale->setValue($entity, $this->getCurrentLocale());
+                $this->setReflectionPropertyValue($entity, 'currentLocale', $this->getCurrentLocale());
             }
         }
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     * @param mixed $value
+     */
+    private function setReflectionPropertyValue($object, string $property, $value): void
+    {
+        $reflection = new \ReflectionProperty(get_class($object), $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
     }
 }

--- a/lib/Prezent/Doctrine/Translatable/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/Driver/AnnotationDriver.php
@@ -11,6 +11,7 @@ namespace Prezent\Doctrine\Translatable\Mapping\Driver;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Metadata\ClassMetadata;
 use Metadata\Driver\DriverInterface;
 use Prezent\Doctrine\Translatable\Annotation\CurrentTranslation;
 use Prezent\Doctrine\Translatable\Annotation\FallbackTranslation;
@@ -43,7 +44,7 @@ class AnnotationDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function loadMetadataForClass(\ReflectionClass $class)
+    public function loadMetadataForClass(\ReflectionClass $class): ?ClassMetadata
     {
         if ($class->implementsInterface('Prezent\\Doctrine\\Translatable\\TranslatableInterface')) {
             return $this->loadTranslatableMetadata($class);
@@ -74,12 +75,12 @@ class AnnotationDriver implements DriverInterface
                 $classMetadata->currentLocale = $propertyMetadata;
                 $classMetadata->addPropertyMetadata($propertyMetadata);
             }
-            
+
             if ($this->reader->getPropertyAnnotation($property, 'Prezent\\Doctrine\\Translatable\\Annotation\\FallbackLocale')) {
                 $classMetadata->fallbackLocale = $propertyMetadata;
                 $classMetadata->addPropertyMetadata($propertyMetadata);
             }
-            
+
             if ($annot = $this->reader->getPropertyAnnotation($property, 'Prezent\\Doctrine\\Translatable\\Annotation\\Translations')) {
                 $classMetadata->targetEntity = $annot->targetEntity;
                 $classMetadata->translations = $propertyMetadata;

--- a/lib/Prezent/Doctrine/Translatable/Mapping/Driver/FileDriver.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/Driver/FileDriver.php
@@ -11,6 +11,7 @@ namespace Prezent\Doctrine\Translatable\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use Metadata\ClassMetadata;
 use Metadata\Driver\DriverInterface;
 use Prezent\Doctrine\Translatable\Mapping\TranslatableMetadata;
 use Prezent\Doctrine\Translatable\Mapping\TranslationMetadata;
@@ -36,7 +37,7 @@ abstract class FileDriver implements DriverInterface
      * @param \ReflectionClass $class
      * @return \Metadata\ClassMetadata
      */
-    public function loadMetadataForClass(\ReflectionClass $class)
+    public function loadMetadataForClass(\ReflectionClass $class): ?ClassMetadata
     {
         if ($class->implementsInterface('Prezent\\Doctrine\\Translatable\\TranslatableInterface')) {
             return $this->loadTranslatableMetadata($class->name, $this->readMapping($class->name));

--- a/lib/Prezent/Doctrine/Translatable/Mapping/TranslatableMetadata.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/TranslatableMetadata.php
@@ -58,7 +58,7 @@ class TranslatableMetadata extends MergeableClassMetadata
     /**
      * {@inheritdoc}
      */
-    public function merge(MergeableInterface $object)
+    public function merge(MergeableInterface $object): void
     {
         if (!$object instanceof self) {
             throw new \InvalidArgumentException(sprintf('$object must be an instance of %s.', __CLASS__));

--- a/lib/Prezent/Doctrine/Translatable/Mapping/TranslationMetadata.php
+++ b/lib/Prezent/Doctrine/Translatable/Mapping/TranslationMetadata.php
@@ -57,7 +57,7 @@ class TranslationMetadata extends MergeableClassMetadata
     /**
      * {@inheritdoc}
      */
-    public function merge(MergeableInterface $object)
+    public function merge(MergeableInterface $object): void
     {
         if (!$object instanceof self) {
             throw new \InvalidArgumentException(sprintf('$object must be an instance of %s.', __CLASS__));

--- a/tests/Prezent/Tests/Doctrine/Translatable/EventListener/TranslatableListenerValidationTest.php
+++ b/tests/Prezent/Tests/Doctrine/Translatable/EventListener/TranslatableListenerValidationTest.php
@@ -2,18 +2,19 @@
 
 namespace Prezent\Tests\Doctrine\Translatable\Mapping;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Prezent\Doctrine\Translatable\Mapping\MappingException;
 use Prezent\Tests\Tool\ORMTestCase;
 
 class TranslatableListenerValidationTest extends ORMTestCase
 {
-    /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
-     */
     public function testAnnotationValidation()
     {
+        $this->expectException(AnnotationException::class);
+
         $classMetadata = new ClassMetadata('Prezent\Tests\Fixture\BadMapping');
         $classMetadata->initializeReflection(new RuntimeReflectionService());
 
@@ -22,11 +23,10 @@ class TranslatableListenerValidationTest extends ORMTestCase
         $this->getTranslatableListener()->loadClassMetadata($eventArgs);
     }
 
-    /**
-     * @expectedException Prezent\Doctrine\Translatable\Mapping\MappingException
-     */
     public function testClassMetadataValidation()
     {
+        $this->expectException(MappingException::class);
+
         $classMetadata = new ClassMetadata('Prezent\Tests\Fixture\BadMappingTranslation');
         $classMetadata->initializeReflection(new RuntimeReflectionService());
 

--- a/tests/Prezent/Tests/Doctrine/Translatable/Mapping/ClassMetadataTest.php
+++ b/tests/Prezent/Tests/Doctrine/Translatable/Mapping/ClassMetadataTest.php
@@ -3,6 +3,7 @@
 namespace Prezent\Tests\Doctrine\Translatable\Mapping;
 
 use PHPUnit\Framework\TestCase;
+use Prezent\Doctrine\Translatable\Mapping\MappingException;
 use Prezent\Doctrine\Translatable\Mapping\PropertyMetadata;
 use Prezent\Doctrine\Translatable\Mapping\TranslatableMetadata;
 use Prezent\Doctrine\Translatable\Mapping\TranslationMetadata;
@@ -51,20 +52,18 @@ class ClassMetadataTest extends TestCase
         $this->assertSame($meta->locale, $meta->propertyMetadata['locale']);
     }
 
-    /**
-     * @expectedException Prezent\Doctrine\Translatable\Mapping\MappingException
-     */
     public function testTranslatableValidation()
     {
+        $this->expectException(MappingException::class);
+
         $meta = new TranslatableMetadata('Prezent\\Tests\\Fixture\\Basic');
         $meta->validate();
     }
 
-    /**
-     * @expectedException Prezent\Doctrine\Translatable\Mapping\MappingException
-     */
     public function testTranslationValidation()
     {
+        $this->expectException(MappingException::class);
+
         $meta = new TranslationMetadata('Prezent\\Tests\\Fixture\\BasicTranslation');
         $meta->validate();
     }


### PR DESCRIPTION
This PR adds support for jms/metadata v2, this keeps full backwards compatibility with the v1 version as well. 

### BC break
The the minimum PHP version has to be raised to 7.1.0, because of the addition of nullable return types. Hopefully this isn't too big of an issue, since PHP 7.0 and below have already EoL'd. Though it would probably require a major version bump.