### PR TITLE
Improve XML mapping

### DIFF
--- a/doc/xml-mapping.md
+++ b/doc/xml-mapping.md
@@ -20,21 +20,22 @@ $metadataFactory  = new MetadataFactory($xmlDriver);
 ## Xml mapping example
 
 ```xml
-# BlogPost.orm.xml
+<!-- BlogPost.orm.xml -->
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
-                  xmlns:prezent="prezent"
+                  xmlns:prezent="https://prezent.nl/schemas/doctrine-translatable"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
-                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd
+                                      https://prezent.nl/schemas/doctrine-translatable
+                                      https://prezent.nl/schemas/doctrine-translatable-3.0.xsd">
 
     ...
 
-        <!-- field="translations" #optional (default: translations) -->
-        <!-- target-entity="BlogPostTranslation" #optional (default: [EntityName]Translation) -->
-        <!-- current-locale="currentLocale" fallback-locale="fallbackLocale"  #optional -->
-        <!-- fallback-locale="fallbackLocale" #optional -->
-        <prezent:translatable field="translations" target-entity="BlogPostTranslation" current-locale="currentLocale" fallback-locale="fallbackLocale"/>
+        <prezent:translatable 
+            translations="translations" 
+            target-entity="BlogPostTranslation" 
+            current-locale="currentLocale" 
+            fallback-locale="fallbackLocale"/>
 
     ...
 
@@ -42,23 +43,18 @@ $metadataFactory  = new MetadataFactory($xmlDriver);
 ```
 
 ```xml
-# BlogPostTranslation.orm.xml
+<!-- BlogPostTranslation.orm.xml -->
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
-                  xmlns:prezent="prezent"
+                  xmlns:prezent="https://prezent.nl/schemas/doctrine-translatable"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
-                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd
+                                      https://prezent.nl/schemas/doctrine-translatable
+                                      https://prezent.nl/schemas/doctrine-translatable-3.0.xsd">
 
     ...
 
-        <field name="locale" column="locale" type="string" length="2">
-            <prezent:locale />
-        </field>
-
-        <!-- field="translatable" #optional (default: translatable) -->
-        <!-- target-entity="BlogPost" # optional (default: entity name without "Translation" suffix) -->
-        <prezent:translatable field="translatable" target-entity="BlogPost"/>
+        <prezent:translation translatable="translatable" target-entity="BlogPost" referenced-column-name="id" locale="locale"/>
 
     ...
 

--- a/schemas/doctrine-translatable.xsd
+++ b/schemas/doctrine-translatable.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="https://prezent.nl/schemas/doctrine-translatable">
+    <xs:element name="translatable">
+        <xs:complexType>
+            <xs:attribute name="translations" type="xs:string" default="translations" use="optional"/>
+            <xs:attribute name="target-entity" type="xs:string" use="optional"/>
+            <xs:attribute name="current-locale" type="xs:string" default="currentLocale" use="optional"/>
+            <xs:attribute name="fallback-locale" type="xs:string" default="fallbackLocale" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="translation">
+        <xs:complexType>
+            <xs:attribute name="translatable" type="xs:string" default="translatable" use="optional"/>
+            <xs:attribute name="target-entity" type="xs:string" use="optional"/>
+            <xs:attribute name="referenced-column-name" type="xs:string" default="id" use="optional"/>
+            <xs:attribute name="locale" type="xs:string" default="locale" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/Prezent/Tests/Fixture/xml/Basic.xml
+++ b/tests/Prezent/Tests/Fixture/xml/Basic.xml
@@ -1,25 +1,26 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-                  xmlns:prezent="prezent">
+                  xmlns:prezent="https://prezent.nl/schemas/doctrine-translatable">
 
-    <entity name="Prezent\Tests\Fixture\Basic" >
+    <entity name="Prezent\Tests\Fixture\Basic">
         <id name="id" column="id" type="integer">
-            <generator strategy="AUTO" />
+            <generator strategy="AUTO"/>
         </id>
 
         <one-to-many field="translations"
                      target-entity="Prezent\Tests\Fixture\BasicTranslation"
                      mapped-by="translatable"
-                orphan-removal="true"
-                index-by="locale"
-                fetch="EXTRA_LAZY">
+                     orphan-removal="true"
+                     index-by="locale"
+                     fetch="EXTRA_LAZY">
             <cascade>
-                <cascade-persist />
-                <cascade-remove />
-                <cascade-merge />
+                <cascade-persist/>
+                <cascade-merge/>
+                <cascade-remove/>
             </cascade>
         </one-to-many>
 
-        <prezent:translatable field="translations" target-entity="Prezent\Tests\Fixture\BasicTranslation" current-locale="currentLocale" fallback-locale="fallbackLocale"/>
+        <prezent:translatable translations="translations" target-entity="Prezent\Tests\Fixture\BasicTranslation"
+                              current-locale="currentLocale" fallback-locale="fallbackLocale"/>
     </entity>
 
 </doctrine-mapping>

--- a/tests/Prezent/Tests/Fixture/xml/BasicTranslation.xml
+++ b/tests/Prezent/Tests/Fixture/xml/BasicTranslation.xml
@@ -1,19 +1,20 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-                  xmlns:prezent="prezent">
+                  xmlns:prezent="https://prezent.nl/schemas/doctrine-translatable">
 
-    <entity name="Prezent\Tests\Fixture\BasicTranslation" >
+    <entity name="Prezent\Tests\Fixture\BasicTranslation">
         <id name="id" column="id" type="integer">
-            <generator strategy="AUTO" />
+            <generator strategy="AUTO"/>
         </id>
 
-        <field name="locale" type="string" />
-        <field name="name" type="string" />
+        <field name="locale" type="string"/>
+        <field name="name" type="string"/>
 
         <many-to-one field="translatable" target-entity="Prezent\Tests\Fixture\Basic" inversed-by="translations">
-            <join-column name="translatable_id" referenced-column-name="id" on-delete="CASCADE" />
+            <join-column name="translatable_id" referenced-column-name="id" on-delete="CASCADE"/>
         </many-to-one>
 
-        <prezent:translatable field="translatable" target-entity="Prezent\Tests\Fixture\Basic" locale="locale"/>
+        <prezent:translation translatable="translatable" target-entity="Prezent\Tests\Fixture\Basic" locale="locale"
+                             referenced-column-name="id"/>
     </entity>
 
 </doctrine-mapping>


### PR DESCRIPTION
Provides a proper XML schema to provide autocomplete and validation on mapping files. I have also cleaned up the code and use separate elements for translatable and translation as they both feature different attributes and requirements.

It is recommended to host the XSD schema somewhere, possibly at `https://prezent.nl/schemas/doctrine-translatable-3.0.xsd`. I added the `3.0` version suffix as I think this would go as a BC break regarding XML mapping.

I based this PR off the current master, not off my other PR. Either one can be merged first.

Please let me know what you think 👍 