### PR TITLE
Add hacky fix for Doctrine Bundle 2.3

### DIFF
--- a/src/Mapping/Driver/DoctrineAdapter.php
+++ b/src/Mapping/Driver/DoctrineAdapter.php
@@ -19,6 +19,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\ObjectManager;
 use Metadata\Driver\DriverChain;
 use Metadata\Driver\DriverInterface;
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
 
 /**
  * Adapt a Doctrine metadata driver
@@ -63,6 +64,12 @@ class DoctrineAdapter
      */
     public static function fromMetadataDriver(MappingDriver $omDriver)
     {
+        if ($omDriver instanceof DoctrineBundleMappingDriver) {
+            $propertyReflection = (new \ReflectionClass($omDriver))->getProperty('driver');
+            $propertyReflection->setAccessible(true);
+            $omDriver = $propertyReflection->getValue($omDriver);
+        }
+
         if ($omDriver instanceof MappingDriverChain) {
             $drivers = array();
             foreach ($omDriver->getDrivers() as $nestedOmDriver) {


### PR DESCRIPTION
Band-Aid Fix for doctrine/doctrine-bundle >= 2.3.0

I'm following the example of [Pull Request 2211 @ doctrine-extensions/DoctrineExtensions](https://github.com/doctrine-extensions/DoctrineExtensions/pull/2211).

This fixes the "Cannot adapt Doctrine driver of class MappingDriver" issue after updating projects to Symfony 5.4 with all dependencies.