### PR TITLE
Fix usage with doctrine/orm 2.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": ">=7.1.0",
         "doctrine/common": "^2.3|^3.0",
+        "doctrine/orm": ">=2.12.0",
         "jms/metadata": "^1.1|^2.0",
         "symfony/cache": "^5.0|^6.0",
         "doctrine/annotations": "^1.13"
     },
     "require-dev": {
-        "doctrine/orm": "^2.3",
         "symfony/yaml": "^5.0|6.0",
         "phpunit/phpunit": "^8.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": ">=7.1.0",
         "doctrine/common": "^2.3|^3.0",
         "jms/metadata": "^1.1|^2.0",
-        "symfony/cache": "^5.0|^6.0"
+        "symfony/cache": "^5.0|^6.0",
+        "doctrine/annotations": "^1.13"
     },
     "require-dev": {
         "doctrine/orm": "^2.3",

--- a/src/Mapping/Driver/DoctrineAdapter.php
+++ b/src/Mapping/Driver/DoctrineAdapter.php
@@ -12,7 +12,7 @@ namespace Prezent\Doctrine\Translatable\Mapping\Driver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as DoctrineAnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver as DoctrineAnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\FileDriver as DoctrineFileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;


### PR DESCRIPTION
doctrine/orm 2.12.0 introduced BC break:

```
AttributeDriver and AnnotationDriver no longer extends parent class from doctrine/persistence
Both these classes used to extend an abstract AnnotationDriver class defined in doctrine/persistence, and no longer do.
```
See: https://github.com/doctrine/orm/blob/2.12.x/UPGRADE.md#bc-break-attributedriver-and-annotationdriver-no-longer-extends-parent-class-from-doctrinepersistence

I had to add `doctrine/annotations` to composer.json to make tests pass. Maybe `doctrine/bundle` should be required too, if DoctrineAdapter class is using `Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver`?

![image](https://user-images.githubusercontent.com/7197178/164266190-a332f3cf-a5b9-4bfa-bdc2-a164428637aa.png)

I am not sure if this is intentional or error caused by new versions of doctrine. Seeing this package for the first time on new project. Let me know if you think this should be fixed too.