### PR TITLE
fix serialization of TranslatableMetadata and TranslationMetadata

### DIFF
--- a/.github/workflows/run-checks-tests.yaml
+++ b/.github/workflows/run-checks-tests.yaml
@@ -1,0 +1,37 @@
+name: Build and tests
+on:
+    push:
+        branches:
+            - 'master'
+            - '[1-9].[0-9]'
+        tags:
+            - '**'
+    pull_request:
+        branches:
+            - '**'
+jobs:
+    cancel:
+        name: Cancel previous workflow runs
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Cancelling
+                uses: styfle/cancel-workflow-action@0.7.0
+                with:
+                    access_token: ${{ github.token }}
+    run-tests:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php-versions: [ '7.4', '8.0', '8.1' ]
+        needs: cancel
+        steps:
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-versions }}
+            -   name: Clone repository
+                uses: actions/checkout@v3
+            -   name: Install composer dependencies
+                run: composer install --no-interaction --optimize-autoloader
+            -   name: Run Unit tests
+                run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "translatable",
         "i18n"
     ],
-    "homepage": "http://www.prezent.nl",
+    "homepage": "https://www.prezent.nl",
     "authors": [{
         "name": "Prezent Internet B.V.",
         "email": "github@prezent.nl"
@@ -20,7 +20,7 @@
         "source": "https://github.com/prezent/doctrine-translatable"
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.4.0",
         "doctrine/common": "^2.3|^3.0",
         "doctrine/orm": ">=2.12.0",
         "jms/metadata": "^1.1|^2.0",

--- a/src/EventListener/TranslatableListener.php
+++ b/src/EventListener/TranslatableListener.php
@@ -114,7 +114,7 @@ class TranslatableListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return array(
             Events::loadClassMetadata,

--- a/src/Mapping/TranslatableMetadata.php
+++ b/src/Mapping/TranslatableMetadata.php
@@ -84,42 +84,36 @@ class TranslatableMetadata extends MergeableClassMetadata
     }
 
     /**
-     * {@inheritdoc}
+     * @return array{targetEntity: string, currentLocale: ?string, fallbackLocale: ?string, translations: ?string, parent: mixed[]}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(array(
-            $this->targetEntity,
-            $this->currentLocale  ? $this->currentLocale->name  : null,
-            $this->fallbackLocale ? $this->fallbackLocale->name : null,
-            $this->translations   ? $this->translations->name        : null,
-            parent::serialize(),
-        ));
+        return [
+                'targetEntity' => $this->targetEntity,
+                'currentLocale' => $this->currentLocale->name ?? null,
+                'fallbackLocale' => $this->fallbackLocale->name ?? null,
+                'translations' => $this->translations->name ?? null,
+                'parent' => $this->serializeToArray(),
+            ];
     }
 
     /**
-     * {@inheritdoc}
+     * @param array{targetEntity: string, currentLocale: ?string, fallbackLocale: ?string, translations: ?string, parent: mixed[]} $data
      */
-    public function unserialize($str)
+    public function __unserialize(array $data): void
     {
-        list (
-            $this->targetEntity,
-            $currentLocale,
-            $fallbackLocale,
-            $translations,
-            $parent
-        ) = unserialize($str);
+        $this->targetEntity = $data['targetEntity'];
 
-        parent::unserialize($parent);
+        $this->unserializeFromArray($data['parent']);
 
-        if ($currentLocale) {
-            $this->currentLocale = $this->propertyMetadata[$currentLocale];
+        if ($data['currentLocale']) {
+            $this->currentLocale = $this->propertyMetadata[$data['currentLocale']];
         }
-        if ($fallbackLocale) {
-            $this->fallbackLocale = $this->propertyMetadata[$fallbackLocale];
+        if ($data['fallbackLocale']) {
+            $this->fallbackLocale = $this->propertyMetadata[$data['fallbackLocale']];
         }
-        if ($translations) {
-            $this->translations = $this->propertyMetadata[$translations];
+        if ($data['translations']) {
+            $this->translations = $this->propertyMetadata[$data['translations']];
         }
     }
 }

--- a/src/Mapping/TranslationMetadata.php
+++ b/src/Mapping/TranslationMetadata.php
@@ -92,39 +92,34 @@ class TranslationMetadata extends MergeableClassMetadata
     }
 
     /**
-     * {@inheritdoc}
+     * @return array{targetEntity: string, referencedColumnName: string, translatable: ?string, locale: ?string, parent: mixed[]}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(array(
-            $this->targetEntity,
-            $this->referencedColumnName,
-            $this->translatable ? $this->translatable->name : null,
-            $this->locale       ? $this->locale->name       : null,
-            parent::serialize(),
-        ));
+        return [
+            'targetEntity' => $this->targetEntity,
+            'referencedColumnName' => $this->referencedColumnName,
+            'translatable' => $this->translatable->name ?? null,
+            'locale' => $this->locale->name ?? null,
+            'parent' => $this->serializeToArray(),
+        ];
     }
 
     /**
-     * {@inheritdoc}
+     * @param array{targetEntity: string, referencedColumnName: string, translatable: ?string, locale: ?string, parent: mixed[]} $data
      */
-    public function unserialize($str)
+    public function __unserialize(array $data): void
     {
-        list (
-            $this->targetEntity,
-            $this->referencedColumnName,
-            $translatable,
-            $locale,
-            $parent
-        ) = unserialize($str);
+        $this->targetEntity = $data['targetEntity'];
+        $this->referencedColumnName = $data['referencedColumnName'];
 
-        parent::unserialize($parent);
+        $this->unserializeFromArray($data['parent']);
 
-        if ($translatable) {
-            $this->translatable = $this->propertyMetadata[$translatable];
+        if ($data['translatable']) {
+            $this->translatable = $this->propertyMetadata[$data['translatable']];
         }
-        if ($locale) {
-            $this->locale = $this->propertyMetadata[$locale];
+        if ($data['locale']) {
+            $this->locale = $this->propertyMetadata[$data['locale']];
         }
     }
 }


### PR DESCRIPTION
Using `parent::serialize` and `parent::unserialize` in class extended from `MergeableClassMetadata` is deprecated and will be removed in future versions. See: https://github.com/schmittjoh/metadata/blob/2.6.1/src/SerializationHelper.php trait, which is used in  `MergeableClassMetadata` class.

Edit: I also created a Github Actions workflow to run tests on PHP 7.4, 8.0 and 8.1, you can see the results here: https://github.com/RobinDvorak/doctrine-translatable/actions/runs/2747314378